### PR TITLE
Fixed: remove extra padding below Tabs.Tab

### DIFF
--- a/packages/tabs/src/index.js
+++ b/packages/tabs/src/index.js
@@ -18,7 +18,9 @@ export const Tabs = ({ children, ...props }) => {
       <Box {...props} __css={{ display: 'inline-flex' }}>
         {tabChildren}
       </Box>
-      <Box __css={{ padding: '10px' }}>{contentChildren}</Box>
+      {contentChildren.length > 0 && (
+        <Box __css={{ padding: '10px' }}>{contentChildren}</Box>
+      )}
     </TabsContext.Provider>
   )
 }

--- a/packages/tabs/test/__snapshots__/Tabs.spec.js.snap
+++ b/packages/tabs/test/__snapshots__/Tabs.spec.js.snap
@@ -85,8 +85,7 @@ Array [
 `;
 
 exports[`Tabs renders correctly with only headers 1`] = `
-Array [
-  .c0 {
+.c0 {
   box-sizing: border-box;
   margin: 0;
   min-width: 0;
@@ -128,42 +127,31 @@ Array [
 }
 
 <div
-    className="c0"
+  className="c0"
+>
+  <div
+    className="c1"
+    onClick={[Function]}
   >
-    <div
-      className="c1"
-      onClick={[Function]}
-    >
-      One
-    </div>
-    <div
-      className="c1"
-      onClick={[Function]}
-    >
-      Two
-    </div>
-    <div
-      className="c1"
-      onClick={[Function]}
-    >
-      Three
-    </div>
-    <div
-      className="c1"
-      onClick={[Function]}
-    >
-      Four
-    </div>
-  </div>,
-  .c0 {
-  box-sizing: border-box;
-  margin: 0;
-  min-width: 0;
-  padding: 10px;
-}
-
-<div
-    className="c0"
-  />,
-]
+    One
+  </div>
+  <div
+    className="c1"
+    onClick={[Function]}
+  >
+    Two
+  </div>
+  <div
+    className="c1"
+    onClick={[Function]}
+  >
+    Three
+  </div>
+  <div
+    className="c1"
+    onClick={[Function]}
+  >
+    Four
+  </div>
+</div>
 `;


### PR DESCRIPTION
(JJ-59): https://oneloop.atlassian.net/browse/JJ-59
Fixed: remove extra padding below Tabs.Tab when there are no Tabs.Content