### PR TITLE
Agrega z-indez al Drawer

### DIFF
--- a/packages/drawer/src/index.js
+++ b/packages/drawer/src/index.js
@@ -55,6 +55,7 @@ const DrawerPortal = ({
     top: 0,
     width: '100%',
     height: '100%',
+    zIndex:100,
   }
 
   const drawerContentInitial = {


### PR DESCRIPTION
# [JJ-71 Modificar el z-index de Drawer](https://oneloop.atlassian.net/browse/JJ-71)

## Story

Se modifica el z-index del Drawer

## Acceptance criteria

Esto se realiza para que tape los elementos que se encuentran detrás y sólo se vea el Drawer mismo

## Affected sections

- packages/drawer/src/index.js

## Test instructions

- [ ] Open the application
- [ ] Click on the Drawer component
- [ ] Open the Drawer component