### PR TITLE
JJ-76 Fix to Github Actions - Steps fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,12 +54,14 @@ jobs:
           git config --global user.name "${{secrets.GIT_USER}}"
 
       - name: Update lerna packages
+        env:
+          GH_TOKEN: ${{secrets.GIT_TOKEN}}
         run: |
           cd node_modules/.bin
           lerna version patch --yes
 
       - name: Publish New Jopi version to NPM
-        run: lerna publish from-package -y --no-verify-access
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           GH_TOKEN: ${{secrets.GIT_TOKEN}}
+        run: lerna publish from-package -y --no-verify-access


### PR DESCRIPTION
# [JJ-76 Fix to Github Actions](https://oneloop.atlassian.net/browse/JJ-76)
## Changelog
Fix to the Github Action that are added for PR to branch **development** and for push to branch **master**.
All the component packages update their versions.
Now use the git token

## Acceptance criteria
When someone makes a PR to **development** branch it must run the GitHub actions with only the tests, and when someone approves a PR to **master** and makes the push it must run the test, compile and publish a new version of Jopi in npmjs.org

## Affected sections
- .github/workflows/publish.yml

## Test instructions
- [x] Make a PR to development
- [x] Click on "Actions" at github.com
- [x] Look all the steps running, if all it's ok it must finish with a merge
- [x] Make a PR to master
- [x] When approved, the "Actions"should start
- [x] Look all the steps running, if all it's ok it must finish with a publish on npmjs.org if there something new to publish
