### PR TITLE
JJ-76 Fix to Github Actions - Return to master branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - development
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
# [JJ-76 Fix to Github Actions](https://oneloop.atlassian.net/browse/JJ-76)
## Changelog
Fix to the Github Action that are added for PR to branch **development** and for push to branch **master**.
All the component packages update their versions.
Now use the git token
Now use a ssh private key

## Acceptance criteria
When someone makes a PR to **development** branch it must run the GitHub actions with only the tests, and when someone approves a PR to **master** and makes the push it must run the test, compile and publish a new version of Jopi in npmjs.org

## Affected sections
- .github/workflows/publish.yml

## Test instructions
- [x] Make a PR to development
- [x] Click on "Actions" at github.com
- [x] Look all the steps running, if all it's ok it must finish with a merge
- [x] Make a PR to master
- [x] When approved, the "Actions"should start
- [x] Look all the steps running, if all it's ok it must finish with a publish on npmjs.org if there something new to publish
