### PR TITLE
JJ-76 Fix to Github Actions - Lerna update package on publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,3 +28,48 @@ jobs:
 
       - name: Build Jopi
         run: yarn build
+
+  publish:
+    needs: build
+    name: Publish New Jopi Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Configure git credentials
+        uses: OleksiyRudenko/gha-git-credentials@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Installing node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Installing npm & lerna
+        run: |
+          npm install
+          npm install --global lerna
+
+      - name: Set Git config
+        run: |
+          git config --global user.email "${{secrets.GIT_EMAIL}}"
+          git config --global user.name "${{secrets.GIT_USER}}"
+
+      - name: Update lerna packages
+        env:
+          GH_TOKEN: ${{secrets.GIT_TOKEN}}
+        run: |
+          cd node_modules/.bin
+          lerna version patch --yes
+
+      - name: Publish New Jopi version to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          GH_TOKEN: ${{secrets.GIT_TOKEN}}
+        run: lerna publish from-package -y --no-verify-access


### PR DESCRIPTION
# [JJ-76 Fix to Github Actions](https://oneloop.atlassian.net/browse/JJ-76)
## Changelog
Fix to the Github Action that are added for PR to branch **development** and for push to branch **master**.
All the component packages update their versions.
Now use the git token
Now use a ssh private key

## Acceptance criteria
When someone makes a PR to **development** branch it must run the GitHub actions with only the tests, and when someone approves a PR to **master** and makes the push it must run the test, compile and publish a new version of Jopi in npmjs.org

## Affected sections
- .github/workflows/publish.yml

## Test instructions
- [x] Make a PR to development
- [x] Click on "Actions" at github.com
- [x] Look all the steps running, if all it's ok it must finish with a merge
- [x] Make a PR to master
- [x] When approved, the "Actions"should start
- [x] Look all the steps running, if all it's ok it must finish with a publish on npmjs.org if there something new to publish
