### PR TITLE
JJ-73 Create New Textarea Component add "textarea" to jopijs/package.json dependencies

### DIFF
--- a/packages/jopijs/package.json
+++ b/packages/jopijs/package.json
@@ -27,6 +27,7 @@
     "@oneloop/table": "^1.2.52",
     "@oneloop/tabs": "^1.4.27",
     "@oneloop/text": "^1.2.52",
+    "@oneloop/textarea": "^1.0.1",
     "styled-components": "^5.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
# [JJ-73 Create New Textarea Component](https://oneloop.atlassian.net/browse/JJ-76)
## Changelog
Add textarea to the jopijs/package.json dependencies

## Acceptance criteria
"@oneloop/textarea": "^1.0.1", appears in jopijs/package.json

## Affected sections
- . jopijs/package.json

## Test instructions
- [ ] Open project
- [ ] Navigate to  jopijs/package.json
- [ ] Check that "@oneloop/textarea": "^1.0.1" is in "dependencies"
