### PR TITLE
Split jobs in 'build' and 'publish' again

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,11 +45,6 @@ jobs:
       - name: Build Jopi
         run: yarn build
 
-      - name: Look up for lib folder in Alert package
-        run: |
-          cd packages/alert 
-          ls
-
       - name: Set Git config
         run: |
           git config --global user.email "${{secrets.GIT_EMAIL}}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,33 @@ jobs:
       - name: Build Jopi
         run: yarn build
 
+  publish:
+    needs: build
+    name: Publish New Jopi Version in NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Configure git credentials
+        uses: OleksiyRudenko/gha-git-credentials@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Installing node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Installing npm & lerna
+        run: |
+          npm install
+          npm install --global lerna
+
       - name: Set Git config
         run: |
           git config --global user.email "${{secrets.GIT_EMAIL}}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Installing yarn
         run: yarn install
 
-      - name: Run lerna info
-        run: lerna info
-
       - name: Run tests
         run: yarn test
 


### PR DESCRIPTION
# [New Jopi Version]()
## Changelog
Split previous unified job in two again: build and publish. This is WIP and there are redundant steps.
Remove "lerna info" command as it's no needed anymore
Remove search for lib folder in Alert package

## Acceptance criteria
Changes must appear in modified files

## Affected sections
- .github/workflows/publish.yml

## Test instructions
- [ ] Make a PR to fix-github-actions
- [ ] Click on "Actions" at github.com
- [ ] Look all the steps running, if all it's ok it must finish with a publish on npmjs.org if there something new to publish
