### PR TITLE
Unit again build & publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,8 @@ on:
       - fix-github-actions
 
 jobs:
-  build:
-    name: Build Jopi
+  build-and-publish:
+    name: Build Jopi & Publish New Version in NPM
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,7 +25,7 @@ jobs:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Installing npm & lerna
+      - name: Installing npm
         run: |
           npm install
           npm install --global lerna
@@ -42,43 +42,10 @@ jobs:
       - name: Build Jopi
         run: yarn build
 
-  publish:
-    needs: build
-    name: Publish New Jopi Version in NPM
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      - name: Configure git credentials
-        uses: OleksiyRudenko/gha-git-credentials@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Installing node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Installing npm & lerna
-        run: |
-          npm install
-          npm install --global lerna
-
       - name: Set Git config
         run: |
           git config --global user.email "${{secrets.GIT_EMAIL}}"
           git config --global user.name "${{secrets.GIT_USER}}"
-
-      - name: Look up for lib folder in Alert package
-        run: |
-          ls
-          cd packages/alert
-          ls
 
       - name: Update lerna packages
         env:


### PR DESCRIPTION
# [New Jopi Version]()
## Changelog
Go back and merge both jobs again

## Acceptance criteria
Changes must appear in modified files

## Affected sections
- .github/workflows/publish.yml

## Test instructions
- [ ] Make a PR to fix-github-actions
- [ ] Click on "Actions" at github.com
- [ ] Steps should run without failing
- [ ] Go to https://www.npmjs.com/package/@oneloop/jopijs, a new version must have been published
- [ ] Download new version in a project (yarn add @oneloop/jopijs)
- [ ] Check that node_modules/@oneloop/alert (or any other) has the **lib** folder in it