### PR TITLE
Fix incorrect import in jopijs/index.js

### DIFF
--- a/packages/jopijs/src/index.js
+++ b/packages/jopijs/src/index.js
@@ -18,7 +18,7 @@ import { Table } from '@oneloop/table'
 import { Tabs } from '@oneloop/tabs'
 import { Text, Heading } from '@oneloop/text'
 import { Textarea } from '@oneloop/textarea'
-import { DatePicker } from '@oneloop/datepicker'
+import { Datepicker } from '@oneloop/datepicker'
 import { ThemeProvider } from 'styled-components'
 
 export {
@@ -45,6 +45,6 @@ export {
   useFilterData,
   Table,
   Image,
-  DatePicker,
+  Datepicker,
   ThemeProvider,
 }


### PR DESCRIPTION
# [DT-226 Corregir estilos Datepicker](https://tokkolabs.atlassian.net/browse/DT-226)

## Story

Arreglar errores del Datepicker que impiden usarlo. El import en jopijs/index.js era incorrecto.

## Acceptance criteria

El Datepicker debe funcionar bien en la storybook page

## Affected sections

- packages/jopijs/src/index.js 

## Test instructions

- [ ] Abrir la app
- [ ] Click en "Datepicker"
- [ ] Controlar que se vea y reaccione según lo esperado
