### PR TITLE
Add wepack.config.js file with css-loader rules

### DIFF
--- a/packages/datepicker/src/Datepicker.stories.js
+++ b/packages/datepicker/src/Datepicker.stories.js
@@ -3,7 +3,7 @@ import { es as locale } from 'date-fns/locale'
 
 import { Datepicker } from '.'
 import { Box } from '@oneloop/box'
-import './datepicker.css'
+// import './datepicker.css'
 import './myStyle.css'
 
 export default {

--- a/packages/datepicker/src/index.js
+++ b/packages/datepicker/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import DatePicker from 'react-datepicker'
-// import './datepicker.css'
+import './datepicker.css'
 
 export const Datepicker = (props) => {
   return <DatePicker {...props} />

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+}


### PR DESCRIPTION
# [DT-226 Corregir estilos datepicker](https://tokkolabs.atlassian.net/browse/DT-226)

## Story
El componente Datepicker tiene un archivo css donde se definene sus estilos por defecto. Necesitamos qe ese archivo sea parte del paquete que se sube a NPM.
Se creó el archivo webpack.config.js para configurar el uso de css-loader (que transforma los archivos .css en algo que Webpack pueda interpretar)

## Acceptance criteria

El paquete publicado en NPM tiene el archivo datepicker.css

## Affected sections
- packages/datepicker/src/Datepicker.stories.js
- packages/datepicker/src/index.js
- webpack.config.js



