### PR TITLE
Agrega funcionalidad de cierre de alerts

### DIFF
--- a/packages/alert/src/Alert.stories.js
+++ b/packages/alert/src/Alert.stories.js
@@ -57,3 +57,4 @@ export const danger = () =>
       </React.Fragment>
     )
   })
+  

--- a/packages/alert/src/Alert.stories.js
+++ b/packages/alert/src/Alert.stories.js
@@ -9,10 +9,6 @@ export default {
   title: 'Design System|Alert',
 }
 
-// export const success = () => (
-//   <Alert text="Éxito!!! Pudiste hacer todo lo que querías y te salió pipi cucu!" />
-// )
-
 export const success = () =>
   React.createElement(() => {
     const [openAlert, setOpenAlert] = useToggle(false)

--- a/packages/alert/src/Alert.stories.js
+++ b/packages/alert/src/Alert.stories.js
@@ -57,4 +57,3 @@ export const danger = () =>
       </React.Fragment>
     )
   })
-  

--- a/packages/alert/src/Alert.stories.js
+++ b/packages/alert/src/Alert.stories.js
@@ -1,4 +1,6 @@
 import React from 'react'
+import { useToggle } from '@oneloop/hooks'
+import { Button } from '@oneloop/button'
 
 import { Alert } from '.'
 
@@ -7,12 +9,51 @@ export default {
   title: 'Design System|Alert',
 }
 
-export const success = () => (
-  <Alert text="Éxito!!! Pudiste hacer todo lo que querías y te salió pipi cucu!" />
-)
+// export const success = () => (
+//   <Alert text="Éxito!!! Pudiste hacer todo lo que querías y te salió pipi cucu!" />
+// )
 
-export const warning = () => <Alert type="warning" text="Danger Zone!!!!" />
+export const success = () =>
+  React.createElement(() => {
+    const [openAlert, setOpenAlert] = useToggle(false)
+    return (
+      <React.Fragment>
+        <Button onClick={setOpenAlert}>Show alert</Button>
+        <br />
+        <br />
+        {openAlert && (
+          <Alert text="Éxito!!! Pudiste hacer todo lo que querías y te salió pipi cucu!" closeFunction={setOpenAlert} />
+        )}
+      </React.Fragment>
+    )
+  })
 
-export const danger = () => (
-  <Alert type="danger" text="NOOOOOO!!! Perdonanos, explotó todo! :(" />
-)
+export const warning = () =>
+  React.createElement(() => {
+    const [openAlert, setOpenAlert] = useToggle(false)
+    return (
+      <React.Fragment>
+        <Button onClick={setOpenAlert}>Show alert</Button>
+        <br />
+        <br />
+        {openAlert && (
+          <Alert type="warning" text="Danger Zone!!!!" closeFunction={setOpenAlert} />
+        )}
+      </React.Fragment>
+    )
+  })
+
+export const danger = () =>
+  React.createElement(() => {
+    const [openAlert, setOpenAlert] = useToggle(false)
+    return (
+      <React.Fragment>
+        <Button onClick={setOpenAlert}>Show alert</Button>
+        <br />
+        <br />
+        {openAlert && (
+          <Alert type="danger" text="NOOOOOO!!! Perdonanos, explotó todo! :(" closeFunction={setOpenAlert} />
+        )}
+      </React.Fragment>
+    )
+  })

--- a/packages/alert/src/index.js
+++ b/packages/alert/src/index.js
@@ -57,6 +57,7 @@ export const Alert = ({ type = 'success', text, ...props }) => (
       display="inline-flex"
       alignSelf="center"
       mr={2}
+      onClick={() => props.closeFunction()}
     >
       <Times color="#716F6F" m="auto" />
     </Button>

--- a/packages/alert/test/__snapshots__/Alert.spec.js.snap
+++ b/packages/alert/test/__snapshots__/Alert.spec.js.snap
@@ -128,6 +128,7 @@ exports[`Alert danger 1`] = `
   <button
     className="c4"
     display="inline-flex"
+    onClick={[Function]}
     size={32}
   >
     <svg
@@ -279,6 +280,7 @@ exports[`Alert primary default 1`] = `
   <button
     className="c4"
     display="inline-flex"
+    onClick={[Function]}
     size={32}
   >
     <svg
@@ -428,6 +430,7 @@ exports[`Alert warning 1`] = `
   <button
     className="c4"
     display="inline-flex"
+    onClick={[Function]}
     size={32}
   >
     <svg


### PR DESCRIPTION
# [DT-315 Agregar la posibilidad de cerrar el componente de alerts](https://oneloop.atlassian.net/browse/DT-315)

## Story

Se agrega función que cierra los alerts desde la cruz

## Acceptance criteria

Se agrega función que cierra los alerts desde la cruz

## Affected sections
- packages/alert/src/Alert.stories.js
- packages/alert/src/index.js

## Test instructions

- [ ] Open the application
- [ ] Go to the Alerts section
- [ ] Click on the button Show Alert, then click en the cross to close the alert itself
